### PR TITLE
🔀:: 랜덤 오류 해결

### DIFF
--- a/Assets/cardinrange/SpriteArray.cs
+++ b/Assets/cardinrange/SpriteArray.cs
@@ -1,5 +1,4 @@
 using System;
-using Config_Manager;
 using UnityEngine;
 using UnityEngine.UI;
 using Random = UnityEngine.Random;
@@ -19,7 +18,7 @@ namespace cardinrange
         }
         public void SpriteRandom()
         {
-            Random.InitState(DateTime.Now.Day);
+            Random.InitState(DateTime.Now.Year * 10000 + DateTime.Now.Month * 100 + DateTime.Now.Day);
             randomindex = Random.Range(0, Sprites.Length);
             _spriteRenderer.sprite = Sprites[randomindex];
         }

--- a/Assets/cardinrange/SpriteArray.cs
+++ b/Assets/cardinrange/SpriteArray.cs
@@ -18,9 +18,11 @@ namespace cardinrange
         }
         public void SpriteRandom()
         {
+            var prevSeed = Random.seed;
             Random.InitState(DateTime.Now.Year * 10000 + DateTime.Now.Month * 100 + DateTime.Now.Day);
             randomindex = Random.Range(0, Sprites.Length);
             _spriteRenderer.sprite = Sprites[randomindex];
+            Random.InitState(prevSeed);
         }
 
         public void Turnitoff()


### PR DESCRIPTION
랜덤 함수가 오늘 날짜의 '일' 만 참조해 한달마다 카드가 똑같이 나오는 오류 해결